### PR TITLE
Fix seperator line in project cards

### DIFF
--- a/features/projects/components/project-card/project-card.module.scss
+++ b/features/projects/components/project-card/project-card.module.scss
@@ -19,7 +19,7 @@
 
 .bottomContainer {
   padding: space.$s4 space.$s6;
-  border-top: 3px solid color.$gray-200;
+  border-top: 1px solid color.$gray-200;
   display: flex;
   justify-content: flex-end;
 }


### PR DESCRIPTION
This PR fixes the seperator line thickness in the project cards. The border was 3px but it was changed to 1px.