### PR TITLE
Fix navigation arrow when collapsing sidebar

### DIFF
--- a/features/layout/sidebar-navigation/sidebar-navigation.module.scss
+++ b/features/layout/sidebar-navigation/sidebar-navigation.module.scss
@@ -139,3 +139,12 @@
     display: flex;
   }
 }
+
+.collapseMenuItemCollapsed {
+  display: none;
+
+  @media (min-width: breakpoint.$desktop) {
+    display: flex;
+    transform: rotate(180deg);
+  }
+}

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -90,7 +90,11 @@ export function SidebarNavigation() {
               iconSrc="/icons/arrow-left.svg"
               isCollapsed={isSidebarCollapsed}
               onClick={() => toggleSidebar()}
-              className={styles.collapseMenuItem}
+              className={
+                isSidebarCollapsed
+                  ? styles.collapseMenuItemCollapsed
+                  : styles.collapseMenuItem
+              }
             />
           </ul>
         </nav>


### PR DESCRIPTION
This PR fixes the navigation icon when the sidebar collapses. The arrow icon points to the right in the collapsed state, whereas before it stayed pointing to the left.