### PR TITLE
Support button opens user's email app

### DIFF
--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -83,7 +83,10 @@ export function SidebarNavigation() {
               text="Support"
               iconSrc="/icons/support.svg"
               isCollapsed={isSidebarCollapsed}
-              onClick={() => alert("Support")}
+              onClick={() =>
+                (window.location.href =
+                  "mailto:mail@support@prolog-app.com?subject='Support Request:'")
+              }
             />
             <MenuItemButton
               text="Collapse"


### PR DESCRIPTION
This PR has fixed the support button so that it opens the user's email app instead of an alert.