### PR TITLE
Fix issue list number of events and users

### DIFF
--- a/api/issues.types.ts
+++ b/api/issues.types.ts
@@ -12,4 +12,5 @@ export type Issue = {
   stack: string;
   level: IssueLevel;
   numEvents: number;
+  numUsers: number;
 };

--- a/features/issues/components/issue-list/issue-row.tsx
+++ b/features/issues/components/issue-list/issue-row.tsx
@@ -17,7 +17,7 @@ const levelColors = {
 };
 
 export function IssueRow({ projectLanguage, issue }: IssueRowProps) {
-  const { name, message, stack, level, numEvents } = issue;
+  const { name, message, stack, level, numEvents, numUsers } = issue;
   const firstLineOfStackTrace = stack.split("\n")[1];
 
   return (
@@ -43,7 +43,7 @@ export function IssueRow({ projectLanguage, issue }: IssueRowProps) {
         </Badge>
       </td>
       <td className={styles.cell}>{numEvents}</td>
-      <td className={styles.cell}>{numEvents}</td>
+      <td className={styles.cell}>{numUsers}</td>
     </tr>
   );
 }


### PR DESCRIPTION
This PR fixes the issue list on the issues page so that the data for number of users and number of events displays correctly from the api.